### PR TITLE
Host process did not quit after spawned one finishes

### DIFF
--- a/bin/lingon
+++ b/bin/lingon
@@ -49,11 +49,15 @@ cli.launch(function handleArguments(env) {
   var spawnLingonProcess = function spawnLingonProcess() {
     if(lingonProcess) {
       log('Configuration changed. Restarting Lingon process!');
+      lingonProcess.removeAllListeners('exit');
       lingonProcess.kill();
       lingonProcess = null;
     }
 
     lingonProcess = spawn(env.configPath, process.argv.slice(2), { stdio: 'inherit' });
+    lingonProcess.on('exit', function() {
+      process.exit();
+    })
   };
 
   // setting up a file watcher to reload the lingon process when the


### PR DESCRIPTION
Ist just found a small issue with the new watch feature. The host process did not quit after the spawned one finishes (e.g. `build`)
